### PR TITLE
App only lets user edit original task and not newer task user is trying to edit. Changed second task_list to self.id

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,7 +6,7 @@ class Task < ActiveRecord::Base
   scope :incomplete, -> { where(completed: false) }
 
   def param_parts
-    [task_list, task_list]
+    [task_list, self.id]
   end
 
 end


### PR DESCRIPTION
when user tried to edit task description of a newly added task the app would update original task instead of the intended task.  The params def had an array of 2 task_list's so user wasn't accessing intended task.  Changed the second task_list to self.id this sets an objective on the selected task to allow for updates. 
