### PR TITLE
made change in task.rb

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,7 +6,7 @@ class Task < ActiveRecord::Base
   scope :incomplete, -> { where(completed: false) }
 
   def param_parts
-    [task_list, task_list]
+    [task_list_id, id]
   end
 
 end


### PR DESCRIPTION
Fixed bug that cause the problem - If the user try to edit the new task that they created, the site thinks it's editing the _first_ task
But I want to be able to edit any task 
I made changed in "app/models/task.rb" 
I use" [task_list_id, id]" instead of "[task_list, task_list]"
